### PR TITLE
Update PullToRefresh.ts

### DIFF
--- a/src/PullToRefresh/widget/PullToRefresh.ts
+++ b/src/PullToRefresh/widget/PullToRefresh.ts
@@ -79,7 +79,7 @@ class PullToRefreshWrapper extends WidgetBase {
 
     private onSyncSuccess(callback: () => void) {
         window.mx.ui.reload(() => {
-            if (this.progressId) {
+            if (this.progressId || this.progressId === 0) {
                 window.mx.ui.hideProgress(this.progressId);
             }
             this.pullToRefresh.setupEvents();


### PR DESCRIPTION
Ran into a problem where the first progress Id was a 0, which means that the hide never is triggered. Using this solution you always hide. Other solution (less readable) would be ``if (this.progressId !== null && !isNaN(this.progressId)) {``